### PR TITLE
Replace x86 with AnyCPU

### DIFF
--- a/DependencyWalker.Net.Cli/DependencyWalker.Net.Cli.csproj
+++ b/DependencyWalker.Net.Cli/DependencyWalker.Net.Cli.csproj
@@ -19,7 +19,7 @@
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <IntermediateOutputPath>obj.Net4\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>Full</DebugType>
@@ -29,7 +29,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <PlatformTarget>x86</PlatformTarget>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>

--- a/DependencyWalker.Net.sln
+++ b/DependencyWalker.Net.sln
@@ -7,18 +7,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependencyWalker.Net.Cli", 
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2249E403-BFED-4144-8196-6E833B81BC7A}.Debug|x86.ActiveCfg = Debug|x86
-		{2249E403-BFED-4144-8196-6E833B81BC7A}.Debug|x86.Build.0 = Debug|x86
-		{2249E403-BFED-4144-8196-6E833B81BC7A}.Release|x86.ActiveCfg = Release|x86
-		{2249E403-BFED-4144-8196-6E833B81BC7A}.Release|x86.Build.0 = Release|x86
-		{8AAE0BB7-BD7C-46A3-977D-D4964271DC32}.Debug|x86.ActiveCfg = Debug|x86
-		{8AAE0BB7-BD7C-46A3-977D-D4964271DC32}.Debug|x86.Build.0 = Debug|x86
-		{8AAE0BB7-BD7C-46A3-977D-D4964271DC32}.Release|x86.ActiveCfg = Release|x86
-		{8AAE0BB7-BD7C-46A3-977D-D4964271DC32}.Release|x86.Build.0 = Release|x86
+		{2249E403-BFED-4144-8196-6E833B81BC7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2249E403-BFED-4144-8196-6E833B81BC7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2249E403-BFED-4144-8196-6E833B81BC7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2249E403-BFED-4144-8196-6E833B81BC7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8AAE0BB7-BD7C-46A3-977D-D4964271DC32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8AAE0BB7-BD7C-46A3-977D-D4964271DC32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8AAE0BB7-BD7C-46A3-977D-D4964271DC32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8AAE0BB7-BD7C-46A3-977D-D4964271DC32}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DependencyWalker/DependencyWalker.Net.csproj
+++ b/DependencyWalker/DependencyWalker.Net.csproj
@@ -21,12 +21,12 @@
     <IntermediateOutputPath>obj.Net4\$(Configuration)\</IntermediateOutputPath>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
     <ErrorReport>prompt</ErrorReport>
     <OutputPath>bin.Net4\Debug\</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <ErrorReport>prompt</ErrorReport>
     <OutputPath>bin.Net4\Release\</OutputPath>
   </PropertyGroup>


### PR DESCRIPTION
Make the main executable build as AnyCPU rather than forcing x86, to allow it to start as x64 on modern 64-bit windows, which allows loading 64-bit and 32-bit dlls/exe into this process

Fix #5